### PR TITLE
feat: Add Vitest support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ npx code-qualia-ts install
 
 This command automatically detects whether you're working with a Node.js application, React/Vue/Angular project, or a TypeScript library and generates an appropriate configuration file.
 
+### Generate Test Coverage
+
+Before running the analysis, ensure you have test coverage data:
+
+```bash
+# For Jest
+npm test -- --coverage
+
+# For Vitest
+vitest run --coverage
+# or if using npm scripts
+npm run test:coverage
+```
+
 ### Basic Analysis
 
 ```bash
@@ -125,10 +139,12 @@ git_history_days: 90
 
 ## 🔧 Requirements
 
-- **Jest/NYC/C8**: For test coverage data
+- **Jest/Vitest/NYC/C8**: For test coverage data
 - **ESLint with complexity rules**: For code complexity analysis  
 - **Git**: For file change history
 - **TypeScript**: Version 4.0 or higher
+
+> 📝 For Vitest setup instructions, see [docs/VITEST_SETUP.md](docs/VITEST_SETUP.md)
 
 
 ## 🏗️ How It Works

--- a/docs/VITEST_SETUP.md
+++ b/docs/VITEST_SETUP.md
@@ -1,0 +1,59 @@
+# Vitest Setup Guide for Code Qualia
+
+## Installing Vitest with Coverage
+
+```bash
+npm install -D vitest @vitest/coverage-c8
+# or for istanbul coverage
+npm install -D vitest @vitest/coverage-istanbul
+```
+
+## Vitest Configuration
+
+Create a `vitest.config.ts` file:
+
+```typescript
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'c8', // or 'istanbul'
+      reporter: ['json', 'lcov', 'text'],
+      reportsDirectory: './coverage',
+      // Important: ensure coverage-final.json is generated
+      all: true,
+      include: ['src/**/*.ts'],
+      exclude: [
+        'node_modules',
+        'src/**/*.test.ts',
+        'src/**/*.spec.ts',
+      ],
+    },
+  },
+})
+```
+
+## Running Tests with Coverage
+
+```bash
+# Run tests with coverage
+vitest run --coverage
+
+# Or add to package.json scripts
+"scripts": {
+  "test": "vitest",
+  "test:coverage": "vitest run --coverage"
+}
+```
+
+## Using with Code Qualia
+
+After running tests with coverage:
+
+```bash
+# Generate quality analysis
+npx code-qualia-ts generate
+```
+
+The tool will automatically detect and use Vitest's coverage data.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-qualia-ts",
   "version": "1.0.0",
-  "description": "A tool for communicating developer intuition and code quality perception to AI through configurable parameters",
+  "description": "A tool for communicating developer intuition and code quality perception to AI through configurable parameters. Supports Jest, Vitest, NYC, and C8 coverage.",
   "main": "dist/index.js",
   "bin": {
     "code-qualia-ts": "./dist/cli.js"
@@ -21,7 +21,11 @@
     "developer-tools",
     "typescript",
     "ai-tools",
-    "code-analysis"
+    "code-analysis",
+    "jest",
+    "vitest",
+    "coverage",
+    "testing"
   ],
   "author": "",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-qualia-ts",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A tool for communicating developer intuition and code quality perception to AI through configurable parameters. Supports Jest, Vitest, NYC, and C8 coverage.",
   "main": "dist/index.js",
   "bin": {

--- a/src/parsers/coverage-parser.ts
+++ b/src/parsers/coverage-parser.ts
@@ -7,7 +7,7 @@ export class CoverageParser {
     const coveragePath = this.findCoverageFile();
     
     if (!coveragePath) {
-      console.warn('No coverage data found. Run tests with coverage first.');
+      console.warn('No coverage data found. Run tests with coverage first (Jest: npm test -- --coverage, Vitest: vitest run --coverage).');
       return {};
     }
 
@@ -22,9 +22,15 @@ export class CoverageParser {
 
   private findCoverageFile(): string | null {
     const possiblePaths = [
+      // Jest, Vitest (c8/istanbul)
       'coverage/coverage-final.json',
       'coverage/lcov-report/coverage-final.json',
+      // NYC
       '.nyc_output/coverage-final.json',
+      // Vitest specific paths
+      'coverage/tmp/coverage-final.json',
+      '.vitest-coverage/coverage-final.json',
+      // Generic fallback
       'coverage/coverage.json',
     ];
 


### PR DESCRIPTION
## Summary
- Add support for Vitest coverage format in Code Qualia
- Update documentation to include Vitest setup instructions  
- Bump version to 1.1.0 to reflect new feature

## Changes
- **Coverage Parser**: Added Vitest-specific coverage paths (`.vitest-coverage/`, `coverage/tmp/`)
- **Documentation**: Created comprehensive Vitest setup guide in `docs/VITEST_SETUP.md`
- **README**: Updated to mention Vitest support and link to setup guide
- **Package.json**: Updated description and keywords to include Vitest

## Test Plan
- [ ] Verify existing Jest coverage still works
- [ ] Test with a Vitest project using `@vitest/coverage-c8`
- [ ] Test with a Vitest project using `@vitest/coverage-istanbul`
- [ ] Confirm coverage detection works with default Vitest paths
- [ ] Verify the tool correctly parses Vitest coverage data

## Notes
Vitest uses the same Istanbul coverage format as Jest, so the existing coverage parsing logic works without modification. This PR mainly adds path detection for Vitest-specific directory structures.

🤖 Generated with [Claude Code](https://claude.ai/code)